### PR TITLE
Several fixes needed for other IDEs for the correct language support implementation

### DIFF
--- a/res/data/modules.xml
+++ b/res/data/modules.xml
@@ -1,4 +1,4 @@
-<?xml encoding="UTF-8"?>
+<?xml version ="1.0" encoding="UTF-8"?>
 <modules>
     <module name="modules/EditorBasics.xml"/>
     <module name="modules/Completions.xml"/>

--- a/src/training/actions/OpenLessonAction.kt
+++ b/src/training/actions/OpenLessonAction.kt
@@ -3,7 +3,6 @@ package training.actions
 import com.intellij.ide.RecentProjectsManager
 import com.intellij.ide.scratch.ScratchFileService
 import com.intellij.ide.scratch.ScratchRootType
-import com.intellij.lang.Language
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.DataKey
@@ -31,6 +30,7 @@ import training.learn.lesson.Lesson
 import training.learn.lesson.LessonListenerAdapter
 import training.learn.lesson.LessonProcessor
 import training.ui.LearnToolWindowFactory
+import training.util.findLanguageByID
 import java.awt.FontFormatException
 import java.io.IOException
 import java.util.concurrent.ExecutionException
@@ -226,7 +226,7 @@ class OpenLessonAction : AnAction() {
     assert(lesson!!.module != null)
     val myLanguage = lesson.lang
 
-    val languageByID = Language.findLanguageByID(myLanguage)
+    val languageByID = findLanguageByID(myLanguage)
     if (CourseManager.getInstance().mapModuleVirtualFile.containsKey(lesson.module)) {
       vf = CourseManager.getInstance().mapModuleVirtualFile[lesson.module]
       ScratchFileService.getInstance().scratchesMapping.setMapping(vf, languageByID)
@@ -271,7 +271,7 @@ class OpenLessonAction : AnAction() {
         val learnProject = CourseManager.getInstance().learnProject!!
         val sourceRootFile = ProjectRootManager.getInstance(learnProject).contentSourceRoots[0]
         val myLanguage = lesson.lang
-        val languageByID = Language.findLanguageByID(myLanguage)
+        val languageByID = findLanguageByID(myLanguage)
         val extensionFile = languageByID!!.associatedFileType!!.defaultExtension
 
         var fileName = "Test." + extensionFile

--- a/src/training/actions/OpenLessonAction.kt
+++ b/src/training/actions/OpenLessonAction.kt
@@ -17,7 +17,6 @@ import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.util.Computable
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.wm.ToolWindowManager
-import com.intellij.projectImport.ProjectImportBuilder.getCurrentProject
 import training.lang.LangManager
 import training.learn.CourseManager
 import training.learn.CourseManager.LEARN_PROJECT_NAME
@@ -31,6 +30,7 @@ import training.learn.lesson.LessonListenerAdapter
 import training.learn.lesson.LessonProcessor
 import training.ui.LearnToolWindowFactory
 import training.util.findLanguageByID
+import training.util.getCurrentProject
 import java.awt.FontFormatException
 import java.io.IOException
 import java.util.concurrent.ExecutionException

--- a/src/training/lang/AbstractLangSupport.kt
+++ b/src/training/lang/AbstractLangSupport.kt
@@ -21,6 +21,8 @@ import com.intellij.openapi.wm.ToolWindowAnchor
 import java.io.File
 
 abstract class AbstractLangSupport : LangSupport {
+  override val defaultProjectName:String
+    get() = "LearnProject"
 
   override fun needToCheckSDK(): Boolean {
     return true

--- a/src/training/lang/LangManager.kt
+++ b/src/training/lang/LangManager.kt
@@ -1,6 +1,5 @@
 package training.lang
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtensionPoint
 import com.intellij.openapi.components.PersistentStateComponent
 import com.intellij.openapi.components.ServiceManager
@@ -9,6 +8,7 @@ import com.intellij.openapi.components.Storage
 import com.intellij.openapi.extensions.ExtensionPointName
 import training.learn.CourseManager
 import training.ui.LearnToolWindowFactory
+import training.util.findLanguageByID
 
 /**
  * @author Sergey Karashevich
@@ -58,7 +58,7 @@ class LangManager : PersistentStateComponent<LangManager.State> {
 
   fun getLanguageDisplayName(): String {
     if (myState.languageName == null) return "default"
-    return (Language.findLanguageByID(myState.languageName) ?: return "default").displayName
+    return (findLanguageByID(myState.languageName) ?: return "default").displayName
   }
 
   data class State(var languageName: String?)

--- a/src/training/lang/LangSupport.kt
+++ b/src/training/lang/LangSupport.kt
@@ -12,7 +12,7 @@ import com.intellij.openapi.wm.ToolWindowAnchor
 interface LangSupport {
 
     val FILE_EXTENSION: String
-
+    val defaultProjectName: String
     companion object {
         val EP_NAME = "training.TrainingLangExtension"
     }

--- a/src/training/learn/CourseManager.java
+++ b/src/training/learn/CourseManager.java
@@ -48,7 +48,6 @@ public class CourseManager {
 
     private Project learnProject;
     private LearnPanel myLearnPanel;
-    public final static String LEARN_PROJECT_NAME = "LearnProject";
     private ModulesPanel modulesPanel;
     public static final String NOTIFICATION_ID = "Training plugin";
 

--- a/src/training/learn/NewLearnProjectUtil.kt
+++ b/src/training/learn/NewLearnProjectUtil.kt
@@ -22,10 +22,12 @@ import java.io.File
  */
 object NewLearnProjectUtil {
 
-    fun createLearnProject(projectName: String, projectToClose: Project?, langSupport: LangSupport): Project? {
+    fun createLearnProject(projectToClose: Project?, langSupport: LangSupport): Project? {
         val projectManager = ProjectManagerEx.getInstanceEx()
         val allProjectsDir = ProjectUtil.getBaseDir()
         val moduleBuilder: ModuleBuilder? = langSupport.getModuleBuilder()
+        val langSupport = LangManager.getInstance().getLangSupport()
+        val projectName = langSupport.defaultProjectName
 
         try {
             val projectFilePath = allProjectsDir + File.separator + projectName //Project dir
@@ -36,7 +38,7 @@ object NewLearnProjectUtil {
             FileUtil.ensureExists(ideaDir)
 
             val newProject: Project =
-              LangManager.getInstance().getLangSupport().createProject(projectName, projectToClose) ?: return projectToClose!!
+                    langSupport.createProject(projectName, projectToClose) ?: return projectToClose!!
 
             langSupport.applyProjectSdk(newProject)
 

--- a/src/training/ui/views/LanguageChoosePanel.kt
+++ b/src/training/ui/views/LanguageChoosePanel.kt
@@ -1,6 +1,5 @@
 package training.ui.views
 
-import com.intellij.lang.Language
 import com.intellij.lang.LanguageExtensionPoint
 import com.intellij.openapi.actionSystem.ActionManager
 import com.intellij.openapi.actionSystem.AnActionEvent
@@ -12,6 +11,7 @@ import training.lang.LangSupport
 import training.learn.CourseManager
 import training.learn.LearnBundle
 import training.ui.LearnUIManager
+import training.util.findLanguageByID
 import java.awt.Color
 import java.awt.Component
 import java.awt.Dimension
@@ -152,7 +152,7 @@ class LanguageChoosePanel(opaque: Boolean = true, addButton: Boolean = true) : J
         for (langSupportExt in sortedLangSupportExtensions) {
 
             val lessonsCount = CourseManager.getInstance().calcLessonsForLanguage(langSupportExt.instance)
-            val lang = Language.findLanguageByID(langSupportExt.language) ?: continue
+            val lang = findLanguageByID(langSupportExt.language) ?: continue
             val jrb = JRadioButton("${lang!!.displayName} ($lessonsCount lesson${if (lessonsCount != 1) "s" else ""}) ")
             jrb.isOpaque = false
             buttonGroup.add(jrb)

--- a/src/training/util/Utils.kt
+++ b/src/training/util/Utils.kt
@@ -1,7 +1,10 @@
 package training.util
 
+import com.intellij.ide.DataManager
 import com.intellij.lang.Language
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.openapi.components.ServiceManager
+import com.intellij.openapi.project.Project
 import java.io.File
 import java.io.FileFilter
 
@@ -97,4 +100,8 @@ fun findLanguageByID(id: String? ): Language? {
     val effectiveId = if (id!!.toLowerCase() == "cpp"){ "ObjectiveC" }else { id }
     val languageByID = Language.findLanguageByID(effectiveId)
     return languageByID
+}
+
+fun getCurrentProject(): Project? {
+    return CommonDataKeys.PROJECT.getData(DataManager.getInstance().dataContext)
 }

--- a/src/training/util/Utils.kt
+++ b/src/training/util/Utils.kt
@@ -1,5 +1,6 @@
 package training.util
 
+import com.intellij.lang.Language
 import com.intellij.openapi.components.ServiceManager
 import java.io.File
 import java.io.FileFilter
@@ -91,3 +92,9 @@ open class UniqueFilesProvider(private val baseName: String, private val rootDir
 }
 
 fun isPropertyExists(name: String) = System.getProperty(name) != null
+
+fun findLanguageByID(id: String? ): Language? {
+    val effectiveId = if (id!!.toLowerCase() == "cpp"){ "ObjectiveC" }else { id }
+    val languageByID = Language.findLanguageByID(effectiveId)
+    return languageByID
+}


### PR DESCRIPTION
1. Improved search for the language ID that allows separating lessons for certain IDEs (not perfect, but no other easy solution)
2. No ide-specific getting of the "current project"
3. Separating the lesson project name to LangSupport
4. Fix for the project file search for the concrete lesson ("project" modules). In certain IDEs there could be multiple content roots.